### PR TITLE
Add flair participation visibility API

### DIFF
--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -32,7 +32,7 @@ class Group
     #   'realm2' => ['perm3', 'perm4', ...] }
     field :minecraft_permissions, type: Hash, default: {}.freeze
 
-    Flair = Struct.new(:symbol, :color, :priority)
+    Flair = Struct.new(:symbol, :color, :priority, :visible_while_participating)
 
     # { realm => {symbol: ... , color: ...} }
     field :minecraft_flair, type: Hash, default: {}.freeze
@@ -41,7 +41,7 @@ class Group
 
     attr_cached :minecraft_flair do
         read_attribute(:minecraft_flair).mash do |realm, flair|
-            [realm, Flair.new(flair['symbol'], flair['color'], flair['priority'])]
+            [realm, Flair.new(flair['symbol'], flair['color'], flair['priority'], flair['visible_while_participating'].nil? ? true : flair['visible_while_participating'])]
         end
     end
 

--- a/app/models/user/groups.rb
+++ b/app/models/user/groups.rb
@@ -15,6 +15,7 @@ class User
                             realm: realm,
                             text: "#{ChatColor[flair.color]}#{flair.symbol}",
                             priority: flair.priority || group.priority,
+                            visible_while_participating: flair.visible_while_participating
                         }
                     end
                 end


### PR DESCRIPTION
Determines if a certain flair should be considered for display when a user is participating in a match. 

Defaults to true 