### PR TITLE
Modernize Play Page

### DIFF
--- a/app/assets/stylesheets/application/index.css
+++ b/app/assets/stylesheets/application/index.css
@@ -21,3 +21,24 @@
     font-weight: bold !important;
     font-size: 14px !important;
 }
+
+.ip-nav {
+  font-size: 16px;
+}
+
+.ip-nav input {
+    font-weight: bold;
+    text-align: center;
+    border: 0;
+    font-size: 12px;
+    width: 140px;
+    box-shadow: none;
+    color: #ffffff;
+    background-color: transparent;
+    margin: 0;
+}
+
+.ip-nav input:hover {
+    cursor: pointer;
+    background-color: transparent;
+}

--- a/app/assets/stylesheets/application/play.css
+++ b/app/assets/stylesheets/application/play.css
@@ -1,7 +1,28 @@
+.ip-small {
+  width: 250px;
+}
+
+.ip-small input {
+    font-size: 20px;
+    font-weight: bold;
+    text-align: center;
+    width: 100%;
+    border: 0;
+    border-radius: 4px;
+    box-shadow: none;
+    color: #ffffff;
+    background-color: transparent;
+    margin: 0;
+}
+
+.ip-small input:hover {
+    cursor: pointer;
+}
+
 @media (min-width: 768px) {
     .play .sidebar {
         /* Contains all of the special wells on the left */
-        width: 340px;
+        width: 440px;
         float: left;
         margin-right: 20px;
     }
@@ -65,18 +86,27 @@
 
 .play .connect td {
     padding: 10px 0;
+    border: 0;
+}
+
+.play .connect .seperator {
+  padding-bottom: 0px;
+  border-bottom-style: solid;
+  border-bottom-width: 1px;
+  border-bottom-color: #d0d0d0;
 }
 
 .play .connect .details {
     font-size: 16px;
     padding-top: 5px;
-    padding-bottom: 10px;
-    border-bottom-style: solid;
-    border-bottom-width: 1px;
-    border-bottom-color: #d0d0d0;
 }
 
-.play .connect .details .location {
+.play .connect .header {
+    text-align: center;
+    padding-bottom: 1px;
+}
+
+.play .connect .header .location {
     font-size: 16px;
     font-weight: bold;
 }

--- a/app/controllers/play_controller.rb
+++ b/app/controllers/play_controller.rb
@@ -22,13 +22,14 @@ class PlayController < ApplicationController
         realms = @servers.flat_map(&:realms).uniq
         @staff = @sessions.select{|s| s.player.is_mc_staff?(realms) }.group_by(&:server)
 
-        @portal_infos = portals.map do |portal|
+        @portal_infos = []
+        portals.each do |portal|
             servers = @servers.select{|s| s.portal == portal }
-            {
+            @portal_infos << {
                 portal: portal,
                 servers: servers.size,
                 players: Server.bungees.online.portal(portal).sum(&:num_online)
-            }
+            } unless servers.empty?
         end
     end
 

--- a/app/views/application/_nav.haml
+++ b/app/views/application/_nav.haml
@@ -11,14 +11,26 @@
         .navbar-collapse.collapse#top-navbar-collapse
             -# Remove right margin to prevent wrapping when nav is full
             %ul.nav.navbar-nav{style: "margin-right: 0;"}
-                %li{:class => (current_page?(main_app.play_path) ? "active" : nil )}
-                    %a{:href => main_app.play_path}
+                %li.dropdown{:class => controller_name == 'maps' || current_page?(main_app.play_path) ? 'active' : nil}
+                    %a.dropdown-toggle{:href => "#", :data => {:toggle => "dropdown"}}
                         %i.fa.fa-play
                         Play
-                %li{:class => (controller_name == 'maps' ? "active" : nil )}
-                    %a{:href => main_app.maps_path}
-                        %i.fa.fa-folder-open
-                        Maps
+                        %b.caret
+                    %ul.dropdown-menu
+                        %li.dropdown-header.ip-nav.center{onClick: 'event.stopPropagation();'}
+                            .row
+                                Connect using
+                                %label.label-primary
+                                    %input.input{type: "text", value: "play.stratus.network", onClick: "this.select();", readonly: true}
+                        %li.divider{:role => "separator", style: 'margin: 0;'}
+                        %li
+                            %a{:href => main_app.play_path}
+                                %i.fa.fa-server
+                                Online Servers
+                        %li
+                            %a{:href => main_app.maps_path}
+                                %i.fa.fa-folder-open
+                                Maps
                 %li.dropdown{:class => controller_name == 'users' || controller_name == 'channels' ? 'active' : nil}
                     %a.dropdown-toggle{:href => "#", :data => {:toggle => "dropdown"}}
                         %i.fa.fa-user

--- a/app/views/play/_multi_portal.haml
+++ b/app/views/play/_multi_portal.haml
@@ -1,0 +1,55 @@
+.sidebar>
+    .well.connect
+        %table.table
+            %thead
+                %tr
+                    %th{colspan: 2} Connect To
+            %tbody
+                - index = 0
+                - @portal_infos.each do |info|
+                    - index += 1
+                    %tr
+                        %td.header
+                            .location= info[:portal].long_name
+                    %tr
+                        %td.hostname
+                            %input.input{type: "text", value: info[:portal].hostname, onClick: "this.select();", readonly: true}
+                    %tr
+                        %td.details.center
+                            %strong= info[:players]
+                            %small
+                                = "player".pluralize(info[:players])
+                                across
+                            %strong= info[:servers]
+                            %small= "server".pluralize(info[:servers])
+                    - unless index == @portal_infos.size
+                        %td.seperator
+    - unless @friends.empty?
+        .well.seen
+            %table.table
+                %thead
+                    %tr
+                        %th{colspan: 2} Online Friends
+                %tbody
+                    = render partial: 'players_by_server', locals: {servers: @friends, global: @global}
+    - unless @staff.empty?
+        .well.seen
+            %table.table
+                %thead
+                    %tr
+                        %th{colspan: 2} Online Staff
+                %tbody
+                    = render partial: 'players_by_server', locals: {servers: @staff, global: @global}
+- if @portal_infos.size > 1
+    .navbar-container>
+        .navbar.navbar-default
+            .container-fluid
+                %ul.nav.navbar-nav
+                    %li{class: ('active' if @global)}
+                        %a{href: play_path} Global
+                    - Portal.listed.each do |portal|
+                        %li{class: ('active' if portal == @portal)}
+                            %a{href: portal_path(portal)}= portal.long_name
+- @servers.each do |server|
+    .server-container>
+        = render partial: 'server', locals: {server: server, global: @global}

--- a/app/views/play/_players_by_server.haml
+++ b/app/views/play/_players_by_server.haml
@@ -1,8 +1,9 @@
 - servers.each do |server, sessions|
-    .col-md-12.server.text-nowrap= server_name(server, global: global)
-    .col-md-12.players
-        - sessions.each do |session|
-            %div
-                %nobr
-                    = avatar_for session.player, 16, link: true
-                    = link_to_user session.player
+    %tr
+        %td.server.text-nowrap= server_name(server, global: global)
+        %td.players
+            - sessions.each do |session|
+                %div
+                    %nobr
+                        = avatar_for session.player, 16, link: true
+                        = link_to_user session.player

--- a/app/views/play/_single_portal.haml
+++ b/app/views/play/_single_portal.haml
@@ -1,0 +1,38 @@
+- players = @portal_infos[0][:players]
+- servers = @portal_infos[0][:servers]
+
+%h2.center
+    Connect using
+    %a.btn.btn-primary.btn-md.ip-small
+        %input.input{type: "text", value: "play.stratus.network", onClick: "this.select();", readonly: true}
+    %br
+    %small
+        Join
+        %strong= players
+        = 'player'.pluralize(players)
+        online
+        across
+        %strong= servers
+        = 'server'.pluralize(servers)
+%hr
+.sidebar>
+    - unless @friends.empty?
+        .well.seen
+            %table.table
+                %thead
+                    %tr
+                        %th{colspan: 2} Online Friends
+                %tbody
+                    = render partial: 'players_by_server', locals: {servers: @friends, global: false}
+    - unless @staff.empty?
+        .well.seen
+            %table.table
+                %thead
+                    %tr
+                        %th{colspan: 2} Online Staff
+                %tbody
+                    = render partial: 'players_by_server', locals: {servers: @staff, global: false}
+
+- @servers.each do |server|
+    .server-container>
+        = render partial: 'server', locals: {server: server, global: false}

--- a/app/views/play/index.haml
+++ b/app/views/play/index.haml
@@ -1,72 +1,10 @@
 - content_for :title do "Play" end
-
-%section.play
-    .row{:style => "margin: 0px; margin-top: -20px"}
-        .page-header
-            %h2
-                Play
-                %small 1.7 - 1.12.2
-        .well.connect
-            .row
-                .col-md-12.connect-header
-                    Connect to
-            %hr
-            .row
-                .col-md-12.connect-padding
-                    .row.hostname
-                        %input.input{type: "text", value: "play.stratus.network", onClick: "this.select();", readonly: true}
-    %hr
-    .row
-        .col-md-6
-            :markdown
-
-                ### **How to connect**
-
-                 1. Open your Minecraft launcher, select one of the supported versions (1.7-1.12.2) and click Play.
-                 2. On the main menu, click the Multiplayer button.
-                 3. Click on "Add Server" and name the server (can be anything you want). For the Server Address, copy the above IP and paste it in.
-                 4. Click done. After that, a server should appear. Double click on it and you will join the lobby.
-                 5. Once in the lobby, you can use the navigator in your inventory to select a server, join it and you will be teleported to that server.
-                 6. After you get teleported to the server you can start participating in the match by using the team selector in your inventory or typing the "/join" command.
-
-        .col-md-6
-            .row
-                :markdown
-
-                    ### **Supported Versions**
-
-                .col-md-6
-                    :markdown
-
-                        - 1.12.2
-                        - 1.12.1
-                        - 1.12
-                        - 1.11
-
-                .col-md-6
-                    :markdown
-
-                        - 1.10
-                        - 1.9
-                        - 1.8
-                        - 1.7
-
-            .row
-                :markdown
-
-                    ### **Regional Proxies**
-
-                    Depending on your location and ISP, you might have better ping by using one of our proxies. These may or may not reduce your ping to the server by routing your internet traffic more efficiently.
-
-                .well.well-sm
-                    %table.table-condensed{:style => "font-style: italic"}
-                        %tbody
-                            %tr
-                                %td{:width => "50%"} America
-                                %td us.stratus.network
-                            %tr
-                                %td Europe
-                                %td eu.stratus.network
-                            %tr
-                                %td Australia
-                                %td au.stratus.network
+%section.clearfix.play
+    .page-header
+        %h1
+            Servers
+            %small Play anywhere, anytime
+    - if @portal_infos.size > 1
+        = render partial: 'multi_portal'
+    - else
+        = render partial: 'single_portal'


### PR DESCRIPTION
* Modernizes (aka brings back the original OCN version of) the Play page to display 
    * active staff
    * online friends 
    * map of each PGM server
* Moves Maps nav item under Play
* Adds IP to the nav under the Play dropdown

The play page logic has also been changed a bit so that:
* If only one `Portal` has active servers:
    * Portal-specific hosts are hidden
    * The main proxy host is shown above the active servers
    * Data center tags are hidden
* If more than one `Portal`s contain active servers:
    * Main proxy IP and header are hidden
    * Datacenter tags are shown
    * The nav showing different datacenter's is shown