### PR TITLE
Add Halloween 2018 Redirect

### DIFF
--- a/config/routes/application.rb
+++ b/config/routes/application.rb
@@ -28,6 +28,7 @@ PGM::Application.routes.draw do
     get '/emoji' => redirect('https://stratus.network/forums/posts/5a7f78de7b10af00010002f9')
     get '/mapmaking' => redirect('https://stratus.network/forums/58e16d72f6e8a83410000047')
     get '/conduct' => redirect('https://stratus.network/forums/topics/59b70619a2e3a9000100010f')
+    get '/halloween' => redirect('https://stratus.network/forums/topics/5bb0c0e15478350001001749')
 
     resources :revisions
     resources :rules


### PR DESCRIPTION
Redirecting  https://stratus.network/halloween to https://stratus.network/forums/topics/5bb0c0e15478350001001749 for the 2018 Halloween event.