### PR TITLE
Fix GitHub unicode assets

### DIFF
--- a/app/assets/javascripts/application/util/emoji.js
+++ b/app/assets/javascripts/application/util/emoji.js
@@ -9,7 +9,7 @@ $(document).ready(function () {
             },
             template: function (value) {
                 var emoji = emojis_map[value];
-                return '<img alt="' + emoji + '" src="https://assets-cdn.github.com/images/icons/emoji' + emoji + '" width="20px" height="20px"/>' + value;
+                return '<img alt="' + emoji + '" src="https://github.githubassets.com/images/icons/emoji' + emoji + '" width="20px" height="20px"/>' + value;
             },
             replace: function (value) {
                 return ':' + value + ': ';

--- a/app/helpers/emoji_helper.rb
+++ b/app/helpers/emoji_helper.rb
@@ -42,6 +42,6 @@ module EmojiHelper
     end
 
     def emoji_img(emoji, emoji_size)
-        %(<img alt="#{emoji.name}" src="#{image_path("https://assets-cdn.github.com/images/icons/emoji/#{emoji.image_filename}")}" style="vertical-align:middle;" width="#{emoji_size}" height="#{emoji_size}"/>)
+        %(<img alt="#{emoji.name}" src="#{image_path("https://github.githubassets.com/images/icons/emoji/#{emoji.image_filename}")}" style="vertical-align:middle;" width="#{emoji_size}" height="#{emoji_size}"/>)
     end
 end


### PR DESCRIPTION
This PR fixes https://github.com/StratusNetwork/issues/issues/276
Like stated on the issue GitHub has moved their assets domain from `assets-cdn.github.com` to `github.githubassets.com`.