### PR TITLE
Add limited public api to be used by anax

### DIFF
--- a/app/controllers/api_public/api_public_controller.rb
+++ b/app/controllers/api_public/api_public_controller.rb
@@ -1,0 +1,31 @@
+module ApiPublic
+  class ApiPublicController < CommonController
+    include JsonController
+    include ParamsHelper
+
+    PROTO_HEADER = 'X-OCN-Version'
+
+    around_filter :set_current_user
+    after_filter :clear_cache
+    respond_to :json
+
+    def clear_cache
+      Cache::RequestManager.clear_request_cache
+    end
+
+    def index
+      respond({:status => true})
+    end
+
+    protected
+
+    def set_current_user
+      User.with_current(User.console_user) { yield }
+    end
+
+    rescue_from Mongoid::Errors::DocumentNotFound do |ex|
+      render_error(404, "#{ex.klass.name} not found matching #{ex.params.inspect}")
+    end
+  end
+end
+

--- a/app/controllers/api_public/users_controller.rb
+++ b/app/controllers/api_public/users_controller.rb
@@ -1,0 +1,19 @@
+module ApiPublic
+  class UsersController < ApiPublicController
+    include FormattingHelper
+
+    public
+
+    def by_username
+      user = User.by_username(params[:username]) or raise NotFound
+      respond({permissions: user.mc_permissions_by_realm, flairs: user.minecraft_flair, banned: user.is_banned?})
+    end
+
+    def by_uuid
+      user = User.by_uuid(params[:uuid]) or raise NotFound
+      respond({permissions: user.mc_permissions_by_realm, flairs: user.minecraft_flair, banned: user.is_banned?})
+    end
+
+  end
+end
+

--- a/app/models/user/groups.rb
+++ b/app/models/user/groups.rb
@@ -8,19 +8,21 @@ class User
 
             # Array of flairs, in display order. Realms may be repeated.
             # [{realm:, text:}, {realm:, text:}, ...]
-            api_synthetic :minecraft_flair do
-                badge_groups.reverse.flat_map do |group|
-                    group.minecraft_flair.map do |realm, flair|
-                        {
-                            realm: realm,
-                            text: "#{ChatColor[flair.color]}#{flair.symbol}",
-                            priority: flair.priority || group.priority,
-                            visible_while_participating: flair.visible_while_participating
-                        }
-                    end
+            api_synthetic :minecraft_flair
+        end # included do
+
+        def minecraft_flair
+            badge_groups.reverse.flat_map do |group|
+                group.minecraft_flair.map do |realm, flair|
+                    {
+                        realm: realm,
+                        text: "#{ChatColor[flair.color]}#{flair.symbol}",
+                        priority: flair.priority || group.priority,
+                        visible_while_participating: flair.visible_while_participating
+                    }
                 end
             end
-        end # included do
+        end
 
         # Occasionally, a seemingly random user will have the group_id of their
         # first membership replaced by a newly created ObjectId that does not

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,8 @@ routes = case PGM::Application.ocn_role
         %w{ api }
     when 'worker'
         []
+    when "api_public"
+        %w{ api_public }
     else
         raise "Weird OCN_ROLE: #{PGM::Application.ocn_role}"
 end

--- a/config/routes/api_public.rb
+++ b/config/routes/api_public.rb
@@ -1,0 +1,12 @@
+PGM::Application.routes.draw do
+  scope module: 'api_public' do
+    root :to => 'api_public#index'
+
+    resources :users, except: [:destroy, :update, :show, :edit, :new, :create, :index] do
+      collection do
+        get "by_username/:username", action: :by_username
+        get "by_uuid/:uuid", action: :by_uuid
+      end
+    end
+  end
+end

--- a/script/rails
+++ b/script/rails
@@ -10,8 +10,9 @@ require File.expand_path('../../config/boot',  __FILE__)
 #     rails octc       # public website
 #     rails avatar     # avatar server
 #     rails api        # API
+#     rails api_public # public api
 
-if %w[octc avatar api].include? ARGV[0]
+if %w[octc avatar api api_public].include? ARGV[0]
     ENV['OCN_ROLE'] = ARGV[0]
     ARGV[0] = 'server'
 end
@@ -26,6 +27,9 @@ case ENV['OCN_ROLE']
     when 'api'
         port = 3010
         pid = 'tmp/pids/api.pid'
+    when 'api_public'
+        port = 3015
+        pid = 'tmp/pids/api_public.pid'
     else
         port = pid = nil
 end


### PR DESCRIPTION
Currently it only has calls for returning information about users
What it returns is:
permissions by realm
flairs by realm
if the player is banned or not

This is read only and only returns information about those 3 things.

Preferably in the future we should hook up anax to the backend properly, but this should work in the meantime.

Also I have tested this, and it seems to work
