### PR TITLE
Fix button group float on team page.

### DIFF
--- a/app/views/teams/show.haml
+++ b/app/views/teams/show.haml
@@ -6,7 +6,7 @@
             %h2.strong= @team.name
         .col-md-2
             %br
-            .btn-group
+            .btn-group.pull-right
                 - if @leader
                     %a.btn.btn-default.btn-sm{:href => edit_team_path(@team)} Manage
                 - if current_user


### PR DESCRIPTION
Button currently has no float so has a gap between it and the edge of the page.

![image](https://user-images.githubusercontent.com/8608892/57226981-2a1b6b00-7008-11e9-80cf-0b9890a3a5e0.png)

All other button groups of the same format use the pull-right helper class.